### PR TITLE
Spurious features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 .DS_Store
 !.gitkeep
 .env
+*.swp

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,9 +1,9 @@
 {
   "source_directories": [
-    "/app/src"
+    "src"
   ],
   "search_path": [
-    "/app/.venv/lib/python3.7/site-packages"
+    ".venv/lib/python3.7/site-packages"
   ],
-  "taint_models_path": "/app/.venv/lib"
+  "taint_models_path": ".venv/lib"
 }

--- a/src/featurestorebundle/attribute/Attribute.py
+++ b/src/featurestorebundle/attribute/Attribute.py
@@ -1,16 +1,11 @@
-from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Optional
 from datetime import datetime
 
-from featurestorebundle.feature.FeatureTemplate import FeatureTemplate
+from featurestorebundle.feature.Feature import Feature
+from featurestorebundle.attribute.AttributeTemplate import AttributeTemplate
 
 
-@dataclass(frozen=True)
-class Feature:
-    name_template: str
-    description_template: str
-    fillna_with: Any
-
+class Attribute(Feature):
     def create_template(
         self,
         category: Optional[str],
@@ -18,8 +13,8 @@ class Feature:
         start_date: Optional[datetime],
         frequency: Optional[str],
         last_compute_date: Optional[datetime],
-    ) -> FeatureTemplate:
-        return FeatureTemplate(
+    ) -> AttributeTemplate:
+        return AttributeTemplate(
             name_template=self.name_template,
             description_template=self.description_template,
             fillna_value=self.fillna_with,

--- a/src/featurestorebundle/attribute/AttributeTemplate.py
+++ b/src/featurestorebundle/attribute/AttributeTemplate.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from featurestorebundle.feature.FeatureTemplate import FeatureTemplate
+
+
+@dataclass(frozen=True)
+class AttributeTemplate(FeatureTemplate):
+    is_feature: bool = False

--- a/src/featurestorebundle/delta/feature/FeaturesPreparerTest.py
+++ b/src/featurestorebundle/delta/feature/FeaturesPreparerTest.py
@@ -40,10 +40,20 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_1 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", "EMPTY", "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", "EMPTY", "str"),
                 ),
                 FeatureInstance(
-                    self.__entity.name, "f2", "this is feature 2", "string", {}, FeatureTemplate("f2", "this is feature 2", "EMPTY", "str")
+                    self.__entity.name,
+                    "f2",
+                    "this is feature 2",
+                    "string",
+                    {},
+                    FeatureTemplate("f2", "this is feature 2", "EMPTY", "str"),
                 ),
             ]
         )
@@ -76,10 +86,20 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_1 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", "EMPTY", "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", "EMPTY", "str"),
                 ),
                 FeatureInstance(
-                    self.__entity.name, "f2", "this is feature 2", "string", {}, FeatureTemplate("f2", "this is feature 2", "EMPTY", "str")
+                    self.__entity.name,
+                    "f2",
+                    "this is feature 2",
+                    "string",
+                    {},
+                    FeatureTemplate("f2", "this is feature 2", "EMPTY", "str"),
                 ),
             ]
         )
@@ -96,7 +116,12 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_2 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f3", "this is feature 3", "string", {}, FeatureTemplate("f3", "this is feature 3", "EMPTY", "str")
+                    self.__entity.name,
+                    "f3",
+                    "this is feature 3",
+                    "string",
+                    {},
+                    FeatureTemplate("f3", "this is feature 3", "EMPTY", "str"),
                 ),
             ]
         )
@@ -138,7 +163,12 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_1 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f3", "this is feature 3", "string", {}, FeatureTemplate("f3", "this is feature 3", "EMPTY", "str")
+                    self.__entity.name,
+                    "f3",
+                    "this is feature 3",
+                    "string",
+                    {},
+                    FeatureTemplate("f3", "this is feature 3", "EMPTY", "str"),
                 ),
             ]
         )
@@ -182,7 +212,12 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_1 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f3", "this is feature 3", "string", {}, FeatureTemplate("f3", "this is feature 3", "EMPTY", "str")
+                    self.__entity.name,
+                    "f3",
+                    "this is feature 3",
+                    "string",
+                    {},
+                    FeatureTemplate("f3", "this is feature 3", "EMPTY", "str"),
                 ),
             ]
         )
@@ -226,7 +261,12 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_1 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f3", "this is feature 3", "string", {}, FeatureTemplate("f3", "this is feature 3", "EMPTY", "str")
+                    self.__entity.name,
+                    "f3",
+                    "this is feature 3",
+                    "string",
+                    {},
+                    FeatureTemplate("f3", "this is feature 3", "EMPTY", "str"),
                 ),
             ]
         )
@@ -241,7 +281,12 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_2 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", "EMPTY", "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", "EMPTY", "str"),
                 ),
             ]
         )
@@ -278,10 +323,20 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_1 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", "EMPTY", "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", "EMPTY", "str"),
                 ),
                 FeatureInstance(
-                    self.__entity.name, "f2", "this is feature 2", "string", {}, FeatureTemplate("f2", "this is feature 2", "EMPTY", "str")
+                    self.__entity.name,
+                    "f2",
+                    "this is feature 2",
+                    "string",
+                    {},
+                    FeatureTemplate("f2", "this is feature 2", "EMPTY", "str"),
                 ),
             ]
         )
@@ -296,7 +351,12 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_2 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f3", "this is feature 3", "string", {}, FeatureTemplate("f3", "this is feature 3", "EMPTY", "str")
+                    self.__entity.name,
+                    "f3",
+                    "this is feature 3",
+                    "string",
+                    {},
+                    FeatureTemplate("f3", "this is feature 3", "EMPTY", "str"),
                 ),
             ]
         )
@@ -331,10 +391,20 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_1 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", "EMPTY", "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", "EMPTY", "str"),
                 ),
                 FeatureInstance(
-                    self.__entity.name, "f2", "this is feature 2", "string", {}, FeatureTemplate("f2", "this is feature 2", None, "str")
+                    self.__entity.name,
+                    "f2",
+                    "this is feature 2",
+                    "string",
+                    {},
+                    FeatureTemplate("f2", "this is feature 2", None, "str"),
                 ),
             ]
         )
@@ -366,7 +436,12 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_2 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f3", "this is feature 3", "string", {}, FeatureTemplate("f3", "this is feature 3", None, "str")
+                    self.__entity.name,
+                    "f3",
+                    "this is feature 3",
+                    "string",
+                    {},
+                    FeatureTemplate("f3", "this is feature 3", None, "str"),
                 ),
             ]
         )
@@ -403,10 +478,20 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_1 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", "EMPTY", "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", "EMPTY", "str"),
                 ),
                 FeatureInstance(
-                    self.__entity.name, "f2", "this is feature 2", "string", {}, FeatureTemplate("f2", "this is feature 2", "EMPTY", "str")
+                    self.__entity.name,
+                    "f2",
+                    "this is feature 2",
+                    "string",
+                    {},
+                    FeatureTemplate("f2", "this is feature 2", "EMPTY", "str"),
                 ),
             ]
         )
@@ -423,7 +508,12 @@ class FeaturesPreparerTest(PySparkTestCase):
         feature_list_2 = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f3", "this is feature 3", "string", {}, FeatureTemplate("f3", "this is feature 3", None, "str")
+                    self.__entity.name,
+                    "f3",
+                    "this is feature 3",
+                    "string",
+                    {},
+                    FeatureTemplate("f3", "this is feature 3", None, "str"),
                 ),
             ]
         )

--- a/src/featurestorebundle/delta/feature/NullHandlerTest.py
+++ b/src/featurestorebundle/delta/feature/NullHandlerTest.py
@@ -156,10 +156,20 @@ class NullHandlerTest(PySparkTestCase):
         input_feature_list = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", "", "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", "", "str"),
                 ),
                 FeatureInstance(
-                    self.__entity.name, "f2", "this is feature 2", "integer", {}, FeatureTemplate("f2", "this is feature 2", None, "int")
+                    self.__entity.name,
+                    "f2",
+                    "this is feature 2",
+                    "integer",
+                    {},
+                    FeatureTemplate("f2", "this is feature 2", None, "int"),
                 ),
             ]
         )
@@ -200,7 +210,12 @@ class NullHandlerTest(PySparkTestCase):
         input_feature_list = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", "", "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", "", "str"),
                 ),
             ]
         )

--- a/src/featurestorebundle/delta/metadata/schema.py
+++ b/src/featurestorebundle/delta/metadata/schema.py
@@ -22,6 +22,7 @@ def get_metadata_columns():
         t.StructField("dtype", t.StringType(), True),
         t.StructField("fillna_value", t.StringType(), True),
         t.StructField("fillna_value_type", t.StringType(), True),
+        t.StructField("is_feature", t.BooleanType(), True),
     ]
 
 

--- a/src/featurestorebundle/feature/FeatureChangesTest.py
+++ b/src/featurestorebundle/feature/FeatureChangesTest.py
@@ -61,10 +61,20 @@ class FeatureChangesTest(PySparkTestCase):
 
         features_with_change = [
             FeatureInstance(
-                "entity", "feature_14d_suffix", "feature suffix in 14 days", "int", {"time_window": "14d"}, feature_with_change_template
+                "entity",
+                "feature_14d_suffix",
+                "feature suffix in 14 days",
+                "int",
+                {"time_window": "14d"},
+                feature_with_change_template,
             ),
             FeatureInstance(
-                "entity", "feature_30d_suffix", "feature suffix in 30 days", "int", {"time_window": "30d"}, feature_with_change_template
+                "entity",
+                "feature_30d_suffix",
+                "feature suffix in 30 days",
+                "int",
+                {"time_window": "30d"},
+                feature_with_change_template,
             ),
         ]
 

--- a/src/featurestorebundle/feature/FeatureInstance.py
+++ b/src/featurestorebundle/feature/FeatureInstance.py
@@ -49,6 +49,10 @@ class FeatureInstance:
         return self.__extra
 
     @property
+    def is_feature(self):
+        return self.__template.is_feature
+
+    @property
     def template(self):
         return self.__template
 
@@ -68,6 +72,7 @@ class FeatureInstance:
             "dtype": self.__dtype,
             "fillna_value": str(self.__template.fillna_value),
             "fillna_value_type": self.__template.fillna_value_type,
+            "is_feature": self.__template.is_feature,
         }
 
     def get_metadata_list(self) -> List[Union[Dict[str, str], str]]:

--- a/src/featurestorebundle/feature/FeatureList.py
+++ b/src/featurestorebundle/feature/FeatureList.py
@@ -63,3 +63,6 @@ class FeatureList:
                 result[name] = (features + [change_feature], time_windows + [time_window])
 
         return [MasterFeature(name, features, time_windows) for name, (features, time_windows) in result.items()]
+
+    def remove_nonfeatures(self) -> "FeatureList":
+        return FeatureList([feature_instance for feature_instance in self.__features if feature_instance.is_feature])

--- a/src/featurestorebundle/feature/FeatureListFactory.py
+++ b/src/featurestorebundle/feature/FeatureListFactory.py
@@ -22,7 +22,9 @@ class FeatureListFactory:
                 row.start_date,
                 row.frequency,
                 row.last_compute_date,
+                row.is_feature,
             )
+
             feature_instance = FeatureInstance(row.entity, row.feature, row.description, row.dtype, row.extra, feature_template)
             feature_instances.append(feature_instance)
 

--- a/src/featurestorebundle/feature/FeatureListFactoryTest.py
+++ b/src/featurestorebundle/feature/FeatureListFactoryTest.py
@@ -42,6 +42,7 @@ class FeaturesListFactoryTest(PySparkTestCase):
                     "string",
                     "",
                     "str",
+                    False,
                 ],
                 [
                     self.__entity.name,
@@ -58,6 +59,7 @@ class FeaturesListFactoryTest(PySparkTestCase):
                     "integer",
                     0,
                     "int",
+                    False,
                 ],
                 [
                     self.__entity.name,
@@ -74,6 +76,7 @@ class FeaturesListFactoryTest(PySparkTestCase):
                     "string",
                     "None",
                     "NoneType",
+                    False,
                 ],
             ],
             get_metadata_schema(),

--- a/src/featurestorebundle/feature/FeatureTemplate.py
+++ b/src/featurestorebundle/feature/FeatureTemplate.py
@@ -15,3 +15,4 @@ class FeatureTemplate:
     start_date: Optional[datetime] = None
     frequency: Optional[str] = None
     last_compute_date: Optional[datetime] = None
+    is_feature: bool = True

--- a/src/featurestorebundle/general_imports.py
+++ b/src/featurestorebundle/general_imports.py
@@ -29,6 +29,7 @@ from featurestorebundle.feature.writer.FeaturesWriter import FeaturesWriter
 # Changes
 from featurestorebundle.feature.Feature import Feature
 from featurestorebundle.feature.FeatureWithChange import FeatureWithChange
+from featurestorebundle.attribute.Attribute import Attribute
 
 # Decorator input functions
 from featurestorebundle.notebook.functions.input_functions import get_features

--- a/src/featurestorebundle/metadata/MetadataTest.py
+++ b/src/featurestorebundle/metadata/MetadataTest.py
@@ -24,10 +24,20 @@ class MetadataTest(PySparkTestCase):
         feature_list = FeatureList(
             [
                 FeatureInstance(
-                    self.__entity.name, "f1", "this is feature 1", "string", {}, FeatureTemplate("f1", "this is feature 1", None, "str")
+                    self.__entity.name,
+                    "f1",
+                    "this is feature 1",
+                    "string",
+                    {},
+                    FeatureTemplate("f1", "this is feature 1", None, "str"),
                 ),
                 FeatureInstance(
-                    self.__entity.name, "f2", "this is feature 2", "string", {}, FeatureTemplate("f2", "this is feature 2", None, "str")
+                    self.__entity.name,
+                    "f2",
+                    "this is feature 2",
+                    "string",
+                    {},
+                    FeatureTemplate("f2", "this is feature 2", None, "str"),
                 ),
             ]
         )
@@ -52,6 +62,7 @@ class MetadataTest(PySparkTestCase):
                     t.StructField("dtype", t.StringType(), True),
                     t.StructField("fillna_value", t.StringType(), True),
                     t.StructField("fillna_value_type", t.StringType(), True),
+                    t.StructField("is_feature", t.BooleanType(), True),
                 ]
             ),
         )

--- a/src/featurestorebundle/notebook/decorator/feature.py
+++ b/src/featurestorebundle/notebook/decorator/feature.py
@@ -116,11 +116,11 @@ class feature(OutputDecorator):  # noqa
 
         feature_templates = [
             feature_.create_template(
-                self.__category,
-                self.__owner,
-                date_parser.parse_date(self.__start_date),  # pyre-ignore[6]
-                self.__frequency,
-                date_parser.parse_date(self.__last_compute_date) if self.__last_compute_date is not None else None,
+                category=self.__category,
+                owner=self.__owner,
+                start_date=date_parser.parse_date(self.__start_date),  # pyre-ignore[6]
+                frequency=self.__frequency,
+                last_compute_date=date_parser.parse_date(self.__last_compute_date) if self.__last_compute_date is not None else None,
             )
             for feature_ in features
         ]


### PR DESCRIPTION
* Metadata-based spurious features support
* New `SpuriousFeature` object for declaration of a spurious feature.
```python
@dp.transformation(data_with_timestamps, display=True)
@feature(
    dp.fs.Feature("num_transactions", "Number of transactions", fillna_with=0),
    dp.fs.SpuriousFeature("sum_amount", "Sum of amount loaned", fillna_with=0),
    category="financial",
)
def client_features(df: DataFrame):
    return (
        df
        .groupBy(entity.get_primary_key())
        .agg(
            f.count("amount").alias("num_transactions"),
            f.sum("amount").alias("sum_amount"),
        )
    )
```
* New metadata column called `spurious` added.
* Argument `include_spurious` (default `False`) added to `FeatureStore.get_latest` method.

---

Update 2022-05-23:
* `SpuriousFeature` renamed to `Attribute`.