### PR TITLE
Changed byte to integer in storage format

### DIFF
--- a/src/featurestorebundle/feature/FeatureInstance.py
+++ b/src/featurestorebundle/feature/FeatureInstance.py
@@ -42,7 +42,7 @@ class FeatureInstance:
 
     @property
     def storage_dtype(self):
-        return f"map<byte,{self.__dtype}>" if self.__template.fillna_value is None else self.__dtype
+        return f"map<integer,{self.__dtype}>" if self.__template.fillna_value is None else self.__dtype
 
     @property
     def extra(self):


### PR DESCRIPTION
Change is due to Databricks Feature Store which does not support byte type.