### PR TITLE
:goal_net: Allow for spaces in column names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feature-store-bundle"
-version = "2.5.0"
+version = "2.5.1-dev.0"
 description = "Feature Store for the Daipe AI Platform"
 readme = "README.md"
 repository = "https://github.com/daipe-ai/feature-store-bundle"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feature-store-bundle"
-version = "2.5.1-dev.0"
+version = "2.5.0"
 description = "Feature Store for the Daipe AI Platform"
 readme = "README.md"
 repository = "https://github.com/daipe-ai/feature-store-bundle"

--- a/src/featurestorebundle/_config/config.yaml
+++ b/src/featurestorebundle/_config/config.yaml
@@ -76,6 +76,8 @@ services:
 
   featurestorebundle.delta.feature.writer.DeltaFeaturesRegistrator:
 
+  featurestorebundle.delta.feature.writer.AddColumnsQueryBuilder:
+
   featurestorebundle.delta.feature.writer.DeltaTableFeaturesPreparer:
 
   featurestorebundle.delta.feature.writer.DeltaPathFeaturesPreparer:
@@ -141,6 +143,10 @@ services:
   featurestorebundle.delta.TableCreator:
     arguments:
       - '@featurestorebundle.logger'
+
+  featurestorebundle.delta.TablePropertySetter:
+
+  featurestorebundle.delta.TablePropertiesSetter:
 
   featurestorebundle.delta.PathCreator:
     arguments:

--- a/src/featurestorebundle/delta/TableCreator.py
+++ b/src/featurestorebundle/delta/TableCreator.py
@@ -43,6 +43,9 @@ class TableCreator:
     def __set_delta_name_column_mapping_mode(self, table_identifier: str):
         self.__table_properties_setter.set_properties(
             table_identifier=table_identifier,
-            property_names=["delta.minReaderVersion", "delta.minWriterVersion", "delta.columnMapping.mode"],
-            property_values=["2", "5", "name"],
+            properties={
+                "delta.minReaderVersion": "2",
+                "delta.minWriterVersion": "5",
+                "delta.columnMapping.mode": "name",
+            },
         )

--- a/src/featurestorebundle/delta/TableCreator.py
+++ b/src/featurestorebundle/delta/TableCreator.py
@@ -26,11 +26,7 @@ class TableCreator:
         if self.__table_existence_checker.exists(full_table_name):
             self.__logger.info(f"Table {full_table_name} already exists, creation skipped. Setting delta.columnMapping.mode to 'name'.")
 
-            self.__table_properties_setter.set_properties(
-                table_identifier=f"{full_table_name}",
-                property_names=["delta.minReaderVersion", "delta.minWriterVersion", "delta.columnMapping.mode"],
-                property_values=["2", "5", "name"],
-            )
+            self.__set_delta_name_column_mapping_mode(table_identifier=full_table_name)
 
             return
 
@@ -40,10 +36,13 @@ class TableCreator:
 
         df.write.partitionBy(*partition_by).format("delta").option("path", path).saveAsTable(f"{full_table_name}")
 
+        self.__set_delta_name_column_mapping_mode(table_identifier=full_table_name)
+
+        self.__logger.info(f"Table {full_table_name} successfully created")
+
+    def __set_delta_name_column_mapping_mode(self, table_identifier: str):
         self.__table_properties_setter.set_properties(
-            table_identifier=f"{full_table_name}",
+            table_identifier=table_identifier,
             property_names=["delta.minReaderVersion", "delta.minWriterVersion", "delta.columnMapping.mode"],
             property_values=["2", "5", "name"],
         )
-
-        self.__logger.info(f"Table {full_table_name} successfully created")

--- a/src/featurestorebundle/delta/TablePropertiesSetter.py
+++ b/src/featurestorebundle/delta/TablePropertiesSetter.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict
 
 from featurestorebundle.delta.TablePropertySetter import TablePropertySetter
 
@@ -7,12 +7,6 @@ class TablePropertiesSetter:
     def __init__(self, table_property_setter: TablePropertySetter) -> None:
         self.__table_property_setter = table_property_setter
 
-    def set_properties(self, table_identifier: str, property_names: List[str], property_values: List[str]):
-        if not self.__validate_arguments(property_names, property_values):
-            raise Exception("Number of elements in property_names has to match with number of elements in property_values.")
-
-        for name, value in zip(property_names, property_values):
+    def set_properties(self, table_identifier: str, properties: Dict[str, str]):
+        for name, value in zip(properties.keys(), properties.values()):
             self.__table_property_setter.set_property(table_identifier=table_identifier, property_name=name, property_value=value)
-
-    def __validate_arguments(self, arg1: List[str], arg2: List[str]) -> bool:
-        return len(arg1) == len(arg2)

--- a/src/featurestorebundle/delta/TablePropertiesSetter.py
+++ b/src/featurestorebundle/delta/TablePropertiesSetter.py
@@ -8,5 +8,5 @@ class TablePropertiesSetter:
         self.__table_property_setter = table_property_setter
 
     def set_properties(self, table_identifier: str, properties: Dict[str, str]):
-        for name, value in zip(properties.keys(), properties.values()):
+        for name, value in properties.items():
             self.__table_property_setter.set_property(table_identifier=table_identifier, property_name=name, property_value=value)

--- a/src/featurestorebundle/delta/TablePropertiesSetter.py
+++ b/src/featurestorebundle/delta/TablePropertiesSetter.py
@@ -1,0 +1,18 @@
+from typing import List
+
+from featurestorebundle.delta.TablePropertySetter import TablePropertySetter
+
+
+class TablePropertiesSetter:
+    def __init__(self, table_property_setter: TablePropertySetter) -> None:
+        self.__table_property_setter = table_property_setter
+
+    def set_properties(self, table_identifier: str, property_names: List[str], property_values: List[str]):
+        if not self.__validate_arguments(property_names, property_values):
+            raise Exception("Number of elements in property_names has to match with number of elements in property_values.")
+
+        for name, value in zip(property_names, property_values):
+            self.__table_property_setter.set_property(table_identifier=table_identifier, property_name=name, property_value=value)
+
+    def __validate_arguments(self, arg1: List[str], arg2: List[str]) -> bool:
+        return len(arg1) == len(arg2)

--- a/src/featurestorebundle/delta/TablePropertySetter.py
+++ b/src/featurestorebundle/delta/TablePropertySetter.py
@@ -1,0 +1,9 @@
+from pyspark.sql import SparkSession
+
+
+class TablePropertySetter:
+    def __init__(self, spark: SparkSession) -> None:
+        self.__spark = spark
+
+    def set_property(self, table_identifier: str, property_name: str, property_value: str):
+        self.__spark.sql(f"ALTER TABLE {table_identifier} SET TBLPROPERTIES ('{property_name}' = '{property_value}');")

--- a/src/featurestorebundle/delta/feature/writer/AddColumnsQueryBuilder.py
+++ b/src/featurestorebundle/delta/feature/writer/AddColumnsQueryBuilder.py
@@ -1,0 +1,11 @@
+from featurestorebundle.feature.FeatureInstance import FeatureInstance
+from featurestorebundle.feature.FeatureList import FeatureList
+
+
+class AddColumnsQueryBuilder:
+    def build_add_columns_query(self, table_identifier: str, feature_list: FeatureList) -> str:
+        add_column_sqls = [self.__build_add_column_query(feature) for feature in feature_list.get_all()]
+        return f"ALTER TABLE {table_identifier} ADD COLUMNS ({','.join(add_column_sqls)})"
+
+    def __build_add_column_query(self, feature: FeatureInstance) -> str:
+        return f'`{feature.name}` {feature.storage_dtype} COMMENT "{feature.description}"'

--- a/src/featurestorebundle/delta/feature/writer/AddColumnsQueryBuilderTest.py
+++ b/src/featurestorebundle/delta/feature/writer/AddColumnsQueryBuilderTest.py
@@ -1,0 +1,42 @@
+import unittest
+from featurestorebundle.feature.FeatureTemplate import FeatureTemplate
+from featurestorebundle.feature.FeatureInstance import FeatureInstance
+from featurestorebundle.feature.FeatureList import FeatureList
+
+from featurestorebundle.delta.feature.writer.AddColumnsQueryBuilder import AddColumnsQueryBuilder
+
+
+class AddColumnQueryBuilderTest(unittest.TestCase):
+    def test_sql_query_builder_build_add_columns_string(self):
+        add_columns_query_builder = AddColumnsQueryBuilder()
+
+        feature_template = FeatureTemplate(
+            name_template="test_name",
+            description_template="test_description",
+            fillna_value="",
+            fillna_value_type="string",
+            location="datalake/path",
+            backend="delta_table",
+            notebook="/no/te/book",
+        )
+        feature_instance = FeatureInstance(
+            entity="test_entity",
+            name="test_name",
+            description="Test description.",
+            dtype="string",
+            variable_type="string",
+            extra={},
+            template=feature_template,
+        )
+        feature_list = FeatureList([feature_instance])
+
+        add_columns_query = add_columns_query_builder.build_add_columns_query(
+            table_identifier="test_database.test_table", feature_list=feature_list
+        )
+        add_columns_query_expected = 'ALTER TABLE test_database.test_table ADD COLUMNS (`test_name` string COMMENT "Test description.")'
+
+        self.assertEqual(add_columns_query_expected, add_columns_query)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/featurestorebundle/delta/feature/writer/DeltaFeaturesMergeConfigGenerator.py
+++ b/src/featurestorebundle/delta/feature/writer/DeltaFeaturesMergeConfigGenerator.py
@@ -42,4 +42,4 @@ class DeltaFeaturesMergeConfigGenerator:
         return {column: self.__wrap_source(column) for column in columns}
 
     def __wrap(self, alias: str, column: str) -> str:  # noqa
-        return f"{alias}.{column}"
+        return f"{alias}.`{column}`"

--- a/src/featurestorebundle/delta/feature/writer/DeltaFeaturesMergeConfigGeneratorTest.py
+++ b/src/featurestorebundle/delta/feature/writer/DeltaFeaturesMergeConfigGeneratorTest.py
@@ -71,7 +71,7 @@ class DeltaFeaturesMergeConfigGeneratorTest(unittest.TestCase):
 
     def test_merge_condition(self):
         self.assertEqual(
-            " AND ".join(f"target.{pk} = source.{pk}" for pk in [self.entity.id_column, self.entity.time_column]),
+            " AND ".join(f"target.`{pk}` = source.`{pk}`" for pk in [self.entity.id_column, self.entity.time_column]),
             self.__config.merge_condition,
         )
 

--- a/src/featurestorebundle/delta/feature/writer/DeltaFeaturesRegistrator.py
+++ b/src/featurestorebundle/delta/feature/writer/DeltaFeaturesRegistrator.py
@@ -10,7 +10,7 @@ class DeltaFeaturesRegistrator:
 
     def register(self, table_identifier: str, feature_list: FeatureList):
         def build_add_column_string(feature: FeatureInstance):
-            return f'{feature.name} {feature.storage_dtype} COMMENT "{feature.description}"'
+            return f'`{feature.name}` {feature.storage_dtype} COMMENT "{feature.description}"'
 
         def build_add_columns_string(table_identifier, feature_list: FeatureList):
             add_column_sqls = [build_add_column_string(feature) for feature in feature_list.get_all()]

--- a/src/featurestorebundle/delta/feature/writer/DeltaFeaturesRegistrator.py
+++ b/src/featurestorebundle/delta/feature/writer/DeltaFeaturesRegistrator.py
@@ -1,26 +1,21 @@
 from typing import List
 from pyspark.sql import SparkSession
-from featurestorebundle.feature.FeatureInstance import FeatureInstance
 from featurestorebundle.feature.FeatureList import FeatureList
+
+from featurestorebundle.delta.feature.writer.AddColumnsQueryBuilder import AddColumnsQueryBuilder
 
 
 class DeltaFeaturesRegistrator:
-    def __init__(self, spark: SparkSession):
+    def __init__(self, spark: SparkSession, add_columns_query_builder: AddColumnsQueryBuilder):
         self.__spark = spark
+        self.__add_columns_query_builder = add_columns_query_builder
 
     def register(self, table_identifier: str, feature_list: FeatureList):
-        def build_add_column_string(feature: FeatureInstance):
-            return f'`{feature.name}` {feature.storage_dtype} COMMENT "{feature.description}"'
-
-        def build_add_columns_string(table_identifier, feature_list: FeatureList):
-            add_column_sqls = [build_add_column_string(feature) for feature in feature_list.get_all()]
-            return f"ALTER TABLE {table_identifier} ADD COLUMNS ({','.join(add_column_sqls)})"
-
         registered_feature_names = self.__get_feature_names(table_identifier)
         unregistered_features = feature_list.get_unregistered(registered_feature_names)
 
         if not unregistered_features.empty():
-            self.__spark.sql(build_add_columns_string(table_identifier, unregistered_features))
+            self.__spark.sql(self.__add_columns_query_builder.build_add_columns_query(table_identifier, unregistered_features))
 
     def __get_feature_names(self, table_identifier: str) -> List[str]:
         column_definitions = self.__spark.sql(f"DESCRIBE TABLE {table_identifier}").collect()


### PR DESCRIPTION
* Column names escaped by backticks.
* Delta properties for tables set in order to allow for special characters in column names.
    * See [this page](https://docs.databricks.com/delta/delta-column-mapping.html) for details. 
* "Add columns string builder" moved to a separate service `AddColumnsQueryBuilder`.
* A Test for `AddColumnsQueryBuilder` added.